### PR TITLE
Refactor Utils

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,10 @@
+$LOAD_PATH.unshift File.join(FileUtils.pwd, 'lib')
+
+require 'rubygems'
+require 'bundler/setup'
+Bundler.require(:default)
+
+require 'revertable_migration'
+require 'migration_utils'
+
 Dir["#{File.dirname(__FILE__)}/lib/tasks/*.rake" ].each{ |rake_file| load rake_file }

--- a/lib/migration_utils.rb
+++ b/lib/migration_utils.rb
@@ -8,9 +8,9 @@ module MigrationUtils
     validation
   end
 
-  def apply_editor(space, field, editor)
+  def apply_editor(space, field, editor, type=nil)
     with_editor_interfaces do |editor_interfaces|
-      editor_interface = editor_interfaces.default(space.id, content_type_id)
+      editor_interface = editor_interfaces.default(space.id, type || content_type_id)
       controls = editor_interface.controls.map do |control|
         control["widgetId"] = editor if control["fieldId"] == field
         control

--- a/lib/migration_utils.rb
+++ b/lib/migration_utils.rb
@@ -10,21 +10,13 @@ module MigrationUtils
 
   def apply_editor(space, field, editor)
     with_editor_interfaces do |editor_interfaces|
-      editor_interface = editor_interfaces.default(space.id, @type)
+      editor_interface = editor_interfaces.default(space.id, content_type_id)
       controls = editor_interface.controls.map do |control|
         control["widgetId"] = editor if control["fieldId"] == field
         control
       end
       editor_interface.update(controls: controls)
       editor_interface.reload
-    end
-  end
-
-  def down
-    with_space do |space|
-      content_type = space.content_types.find(@type)
-      content_type.unpublish
-      content_type.destroy
     end
   end
 

--- a/lib/revertable_migration.rb
+++ b/lib/revertable_migration.rb
@@ -1,0 +1,32 @@
+require 'migration_utils'
+
+class RevertableMigration < ContentfulMigrations::Migration
+  include MigrationUtils
+
+  @@content_type_id = nil
+
+  def initialize(name = self.class.name, version = nil, client = nil, space = nil)
+    raise ContentTypeNotDefined if content_type_id.nil?
+    super(name, version, client, space)
+  end
+
+  def down
+    with_space do |space|
+      content_type = space.content_types.find(content_type_id)
+      content_type.unpublish
+      content_type.destroy
+    end
+  end
+
+  protected
+
+    def content_type_id
+      @content_type_id ||= @@content_type_id
+    end
+
+  class ContentTypeNotDefined < ::StandardError
+    def message
+      "When inheriting from RevertableMigration, you must specify @@content_type_id in your subclass"
+    end
+  end
+end

--- a/lib/revertable_migration.rb
+++ b/lib/revertable_migration.rb
@@ -3,7 +3,9 @@ require 'migration_utils'
 class RevertableMigration < ContentfulMigrations::Migration
   include MigrationUtils
 
-  @@content_type_id = nil
+  class << self
+    attr_accessor :content_type_id
+  end
 
   def initialize(name = self.class.name, version = nil, client = nil, space = nil)
     raise ContentTypeNotDefined if content_type_id.nil?
@@ -21,7 +23,7 @@ class RevertableMigration < ContentfulMigrations::Migration
   protected
 
     def content_type_id
-      @content_type_id ||= @@content_type_id
+      @content_type_id ||= self.class.content_type_id
     end
 
   class ContentTypeNotDefined < ::StandardError

--- a/migrations/20180614000000_create_authors.rb
+++ b/migrations/20180614000000_create_authors.rb
@@ -2,7 +2,7 @@ require_relative '../lib/revertable_migration'
 
 class CreateAuthors < RevertableMigration
 
-  @@content_type_id = 'author'
+  self.content_type_id = 'author'
 
   def up
     with_space do |space|

--- a/migrations/20180614000000_create_authors.rb
+++ b/migrations/20180614000000_create_authors.rb
@@ -1,18 +1,14 @@
-require_relative '../lib/migration_utils'
+require_relative '../lib/revertable_migration'
 
-class CreateAuthors < ContentfulMigrations::Migration
-  include MigrationUtils
+class CreateAuthors < RevertableMigration
 
-  def initialize(name = self.class.name, version = nil, client = nil, space = nil)
-    @type = 'author'
-    super(name, version, client, space)
-  end
+  @@content_type_id = 'author'
 
   def up
     with_space do |space|
       content_type = space.content_types.create(
         name: 'Author',
-        id: @type,
+        id: content_type_id,
         description: 'Person associated with one or more pieces of content'
       )
 

--- a/migrations/20180614000001_create_categories.rb
+++ b/migrations/20180614000001_create_categories.rb
@@ -1,18 +1,12 @@
-require_relative '../lib/migration_utils'
+class CreateCategories < RevertableMigration
 
-class CreateCategories < ContentfulMigrations::Migration
-  include MigrationUtils
-
-  def initialize(name = self.class.name, version = nil, client = nil, space = nil)
-    @type = 'category'
-    super(name, version, client, space)
-  end
+  @@content_type_id = 'category'
 
   def up
     with_space do |space|
       content_type = space.content_types.create(
         name: 'Category',
-        id: @type,
+        id: content_type_id,
         description: 'Content is organized by categories'
       )
 

--- a/migrations/20180614000001_create_categories.rb
+++ b/migrations/20180614000001_create_categories.rb
@@ -1,6 +1,6 @@
 class CreateCategories < RevertableMigration
 
-  @@content_type_id = 'category'
+  self.content_type_id = 'category'
 
   def up
     with_space do |space|

--- a/migrations/20180614000002_create_articles.rb
+++ b/migrations/20180614000002_create_articles.rb
@@ -1,6 +1,6 @@
 class CreateArticles < RevertableMigration
 
-  @@content_type_id = 'article'
+  self.content_type_id = 'article'
 
   def up
     with_space do |space|

--- a/migrations/20180614000002_create_articles.rb
+++ b/migrations/20180614000002_create_articles.rb
@@ -1,18 +1,12 @@
-require_relative '../lib/migration_utils'
+class CreateArticles < RevertableMigration
 
-class CreateArticles < ContentfulMigrations::Migration
-  include MigrationUtils
-
-  def initialize(name = self.class.name, version = nil, client = nil, space = nil)
-    @type = 'article'
-    super(name, version, client, space)
-  end
+  @@content_type_id = 'article'
 
   def up
     with_space do |space|
       content_type = space.content_types.create(
         name: 'Article',
-        id: @type,
+        id: content_type_id,
         description: 'Long-form written content, such as a blog post'
       )
 

--- a/migrations/20180614000003_create_podcasts.rb
+++ b/migrations/20180614000003_create_podcasts.rb
@@ -1,18 +1,12 @@
-require_relative '../lib/migration_utils'
+class CreatePodcasts < RevertableMigration
 
-class CreatePodcasts < ContentfulMigrations::Migration
-  include MigrationUtils
-
-  def initialize(name = self.class.name, version = nil, client = nil, space = nil)
-    @type = 'podcast'
-    super(name, version, client, space)
-  end
+  @@content_type_id = 'podcast'
 
   def up
     with_space do |space|
       content_type = space.content_types.create(
         name: 'Podcast',
-        id: @type,
+        id: content_type_id,
         description: 'Podcast, or a grouping of audio episodes'
       )
 

--- a/migrations/20180614000003_create_podcasts.rb
+++ b/migrations/20180614000003_create_podcasts.rb
@@ -1,6 +1,6 @@
 class CreatePodcasts < RevertableMigration
 
-  @@content_type_id = 'podcast'
+  self.content_type_id = 'podcast'
 
   def up
     with_space do |space|

--- a/migrations/20180614000004_create_episodes.rb
+++ b/migrations/20180614000004_create_episodes.rb
@@ -1,6 +1,6 @@
 class CreateEpisodes < RevertableMigration
 
-  @@content_type_id = 'episode'
+  self.content_type_id = 'episode'
 
   def up
     with_space do |space|

--- a/migrations/20180614000004_create_episodes.rb
+++ b/migrations/20180614000004_create_episodes.rb
@@ -1,18 +1,12 @@
-require_relative '../lib/migration_utils'
+class CreateEpisodes < RevertableMigration
 
-class CreateEpisodes < ContentfulMigrations::Migration
-  include MigrationUtils
-
-  def initialize(name = self.class.name, version = nil, client = nil, space = nil)
-    @type = 'episode'
-    super(name, version, client, space)
-  end
+  @@content_type_id = 'episode'
 
   def up
     with_space do |space|
       content_type = space.content_types.create(
         name: 'Episode',
-        id: @type,
+        id: content_type_id,
         description: 'A podcast episode'
       )
 

--- a/migrations/20180614000005_create_albums.rb
+++ b/migrations/20180614000005_create_albums.rb
@@ -1,18 +1,12 @@
-require_relative '../lib/migration_utils'
+class CreateAlbums < RevertableMigration
 
-class CreateAlbums < ContentfulMigrations::Migration
-  include MigrationUtils
-
-  def initialize(name = self.class.name, version = nil, client = nil, space = nil)
-    @type = 'album'
-    super(name, version, client, space)
-  end
+  @@content_type_id = 'album'
 
   def up
     with_space do |space|
       content_type = space.content_types.create(
         name: 'Album',
-        id: @type,
+        id: content_type_id,
         description: 'A Crossroads music album'
       )
 

--- a/migrations/20180614000005_create_albums.rb
+++ b/migrations/20180614000005_create_albums.rb
@@ -1,6 +1,6 @@
 class CreateAlbums < RevertableMigration
 
-  @@content_type_id = 'album'
+  self.content_type_id = 'album'
 
   def up
     with_space do |space|

--- a/migrations/20180614000006_create_songs.rb
+++ b/migrations/20180614000006_create_songs.rb
@@ -1,18 +1,12 @@
-require_relative '../lib/migration_utils'
+class CreateSongs < RevertableMigration
 
-class CreateSongs < ContentfulMigrations::Migration
-  include MigrationUtils
-
-  def initialize(name = self.class.name, version = nil, client = nil, space = nil)
-    @type = 'song'
-    super(name, version, client, space)
-  end
+  @@content_type_id = 'song'
 
   def up
     with_space do |space|
       content_type = space.content_types.create(
         name: 'Song',
-        id: @type,
+        id: content_type_id,
         description: 'An individual song'
       )
 

--- a/migrations/20180614000006_create_songs.rb
+++ b/migrations/20180614000006_create_songs.rb
@@ -1,6 +1,6 @@
 class CreateSongs < RevertableMigration
 
-  @@content_type_id = 'song'
+  self.content_type_id = 'song'
 
   def up
     with_space do |space|

--- a/migrations/20180614000007_create_videos.rb
+++ b/migrations/20180614000007_create_videos.rb
@@ -1,6 +1,6 @@
 class CreateVideos < RevertableMigration
 
-  @@content_type_id = 'video'
+  self.content_type_id = 'video'
 
   def up
     with_space do |space|

--- a/migrations/20180614000007_create_videos.rb
+++ b/migrations/20180614000007_create_videos.rb
@@ -1,18 +1,12 @@
-require_relative '../lib/migration_utils'
+class CreateVideos < RevertableMigration
 
-class CreateVideos < ContentfulMigrations::Migration
-  include MigrationUtils
-
-  def initialize(name = self.class.name, version = nil, client = nil, space = nil)
-    @type = 'video'
-    super(name, version, client, space)
-  end
+  @@content_type_id = 'video'
 
   def up
     with_space do |space|
       content_type = space.content_types.create(
         name: 'Video',
-        id: @type,
+        id: content_type_id,
         description: 'An individual video'
       )
 
@@ -28,6 +22,7 @@ class CreateVideos < ContentfulMigrations::Migration
       content_type.fields.create(id: 'transcription', name: 'Transcription', type: 'Text')
       content_type.fields.create(id: 'apple_podcasts_url', name: 'Apple Podcasts URL', type: 'Symbol')
       content_type.fields.create(id: 'google_play_url', name: 'Google Play URL', type: 'Symbol')
+
       items = Contentful::Management::Field.new
       items.type = 'Symbol'
       content_type.fields.create(id: 'tags', name: 'Tags', type: 'Array', items: items)

--- a/migrations/20180614000007_create_videos.rb
+++ b/migrations/20180614000007_create_videos.rb
@@ -22,6 +22,7 @@ class CreateVideos < RevertableMigration
       content_type.fields.create(id: 'transcription', name: 'Transcription', type: 'Text')
       content_type.fields.create(id: 'apple_podcasts_url', name: 'Apple Podcasts URL', type: 'Symbol')
       content_type.fields.create(id: 'google_play_url', name: 'Google Play URL', type: 'Symbol')
+      content_type.fields.create(id: 'view_count', name: 'View Count', type: 'Number', disabled: true)
 
       items = Contentful::Management::Field.new
       items.type = 'Symbol'

--- a/migrations/20180614000008_create_series.rb
+++ b/migrations/20180614000008_create_series.rb
@@ -1,18 +1,12 @@
-require_relative '../lib/migration_utils'
+class CreateSeries < RevertableMigration
 
-class CreateSeries < ContentfulMigrations::Migration
-  include MigrationUtils
-
-  def initialize(name = self.class.name, version = nil, client = nil, space = nil)
-    @type = 'series'
-    super(name, version, client, space)
-  end
+  @@content_type_id = 'series'
 
   def up
     with_space do |space|
       content_type = space.content_types.create(
         name: 'Series',
-        id: @type,
+        id: content_type_id,
         description: 'A series has many messages'
       )
 

--- a/migrations/20180614000008_create_series.rb
+++ b/migrations/20180614000008_create_series.rb
@@ -1,6 +1,6 @@
 class CreateSeries < RevertableMigration
 
-  @@content_type_id = 'series'
+  self.content_type_id = 'series'
 
   def up
     with_space do |space|

--- a/migrations/20180614000009_create_messages.rb
+++ b/migrations/20180614000009_create_messages.rb
@@ -1,6 +1,6 @@
 class CreateMessages < RevertableMigration
 
-  @@content_type_id = 'message'
+  self.content_type_id = 'message'
 
   def up
     with_space do |space|

--- a/migrations/20180614000009_create_messages.rb
+++ b/migrations/20180614000009_create_messages.rb
@@ -1,18 +1,12 @@
-require_relative '../lib/migration_utils'
+class CreateMessages < RevertableMigration
 
-class CreateMessages < ContentfulMigrations::Migration
-  include MigrationUtils
-
-  def initialize(name = self.class.name, version = nil, client = nil, space = nil)
-    @type = 'message'
-    super(name, version, client, space)
-  end
+  @@content_type_id = 'message'
 
   def up
     with_space do |space|
       content_type = space.content_types.create(
         name: 'Message',
-        id: @type,
+        id: content_type_id,
         description: 'An individual message from a series'
       )
 

--- a/migrations/20180614135537_create_pages.rb
+++ b/migrations/20180614135537_create_pages.rb
@@ -1,6 +1,6 @@
 class CreatePages < RevertableMigration
 
-  @@content_type_id = 'page'
+  @content_type_id = 'page'
 
   def up
     with_space do |space|

--- a/migrations/20180614135537_create_pages.rb
+++ b/migrations/20180614135537_create_pages.rb
@@ -1,12 +1,12 @@
 class CreatePages < RevertableMigration
 
-  @content_type_id = 'page'
+  self.content_type_id = 'page'
 
   def up
     with_space do |space|
       content_type = space.content_types.create(
         name: 'Page',
-        id: @@content_type_id,
+        id: content_type_id,
         description: 'A piece of content distinguished by a unique path'
       )
       content_type.fields.create(id: 'title', name: 'Title', type: 'Symbol', required: true)

--- a/migrations/20180614135537_create_pages.rb
+++ b/migrations/20180614135537_create_pages.rb
@@ -1,18 +1,12 @@
-require_relative '../lib/migration_utils'
+class CreatePages < RevertableMigration
 
-class CreatePages < ContentfulMigrations::Migration
-  include MigrationUtils
-
-  def initialize(name = self.class.name, version = nil, client = nil, space = nil)
-    @type = 'page'
-    super(name, version, client, space)
-  end
+  @@content_type_id = 'page'
 
   def up
     with_space do |space|
       content_type = space.content_types.create(
         name: 'Page',
-        id: @type,
+        id: @@content_type_id,
         description: 'A piece of content distinguished by a unique path'
       )
       content_type.fields.create(id: 'title', name: 'Title', type: 'Symbol', required: true)

--- a/migrations/20180615112300_add_series_to_messages.rb
+++ b/migrations/20180615112300_add_series_to_messages.rb
@@ -1,5 +1,3 @@
-require_relative '../lib/migration_utils'
-
 class AddSeriesToMessages < ContentfulMigrations::Migration
   include MigrationUtils
 


### PR DESCRIPTION
This PR refactors things so that migrations don't automatically inherit the `down` method, rather any migration that explicitly needs that method, can inherit it from `RevertableMigration`. 