### PR TITLE
- Adds a field to the Page content model called "Meta Description", u…

### DIFF
--- a/migrations/20180614135537_create_pages.rb
+++ b/migrations/20180614135537_create_pages.rb
@@ -9,17 +9,19 @@ class CreatePages < RevertableMigration
         id: content_type_id,
         description: 'A piece of content distinguished by a unique path'
       )
+      validation_for_meta_description = Contentful::Management::Validation.new
+      validation_for_meta_description.size = { min: 100, max: 155 }
+      validation_for_layout = Contentful::Management::Validation.new
+      validation_for_layout.in = ['container-fluid', 'container', 'eight-column']
+
       content_type.fields.create(id: 'title', name: 'Title', type: 'Symbol', required: true)
       content_type.fields.create(id: 'slug', name: 'Slug', type: 'Symbol', required: true, validations: [uniqueness_of])
       content_type.fields.create(id: 'body', name: 'Body', type: 'Text')
       content_type.fields.create(id: 'show_header', name: 'Show Header?', type: 'Boolean', required: true)
       content_type.fields.create(id: 'show_footer', name: 'Show Footer?', type: 'Boolean', required: true)
-      content_type.fields.create(id: 'meta_description', name: 'Meta Description', type: 'Symbol') # to be reflected in a Page content model's SSG-emitted web page metadata (e.g. <meta name="description" value="meta_description">)
       content_type.fields.create(id: 'meta_image', name: 'Meta Image', type: 'Link', link_type: 'Asset')
-
-      validation_in = Contentful::Management::Validation.new
-      validation_in.in = ['container-fluid', 'container', 'eight-column']
-      content_type.fields.create(id: 'layout', name: 'Layout', type: 'Symbol', required: true, validations: [validation_in])
+      content_type.fields.create(id: 'meta_description', name: 'Meta Description', type: 'Symbol', validations: [validation_for_meta_description])
+      content_type.fields.create(id: 'layout', name: 'Layout', type: 'Symbol', required: true, validations: [validation_for_layout])
 
       items = Contentful::Management::Field.new
       items.type = 'Symbol'

--- a/migrations/20180614135537_create_pages.rb
+++ b/migrations/20180614135537_create_pages.rb
@@ -15,6 +15,7 @@ class CreatePages < RevertableMigration
       content_type.fields.create(id: 'show_header', name: 'Show Header?', type: 'Boolean', required: true)
       content_type.fields.create(id: 'show_footer', name: 'Show Footer?', type: 'Boolean', required: true)
       content_type.fields.create(id: 'meta_description', name: 'Meta Description', type: 'Symbol') # to be reflected in a Page content model's SSG-emitted web page metadata (e.g. <meta name="description" value="meta_description">)
+      content_type.fields.create(id: 'meta_image', name: 'Meta Image', type: 'Link', link_type: 'Asset')
 
       validation_in = Contentful::Management::Validation.new
       validation_in.in = ['container-fluid', 'container', 'eight-column']

--- a/migrations/20180614135537_create_pages.rb
+++ b/migrations/20180614135537_create_pages.rb
@@ -14,6 +14,7 @@ class CreatePages < RevertableMigration
       content_type.fields.create(id: 'body', name: 'Body', type: 'Text')
       content_type.fields.create(id: 'show_header', name: 'Show Header?', type: 'Boolean', required: true)
       content_type.fields.create(id: 'show_footer', name: 'Show Footer?', type: 'Boolean', required: true)
+      content_type.fields.create(id: 'meta_description', name: 'Meta Description', type: 'Symbol') # to be reflected in a Page content model's SSG-emitted web page metadata (e.g. <meta name="description" value="meta_description">)
 
       validation_in = Contentful::Management::Validation.new
       validation_in.in = ['container-fluid', 'container', 'eight-column']
@@ -28,5 +29,4 @@ class CreatePages < RevertableMigration
       apply_editor(space, 'slug', 'slugEditor')
     end
   end
-
 end


### PR DESCRIPTION
…ltimately to be reflected in its SSG-emitted web page metadata (e.g. <meta name="description" value="meta_description">)

NOTE: Currently unable to execute the migration from my local machine, but I don't believe I introduced any syntax errors.