### PR TITLE
US14061 - Flagged Video Content

### DIFF
--- a/migrations/20180718154330_add_featured_to_songs.rb
+++ b/migrations/20180718154330_add_featured_to_songs.rb
@@ -16,15 +16,21 @@ class AddFeaturedToSongs < ContentfulMigrations::Migration
     with_space do |space|
       content_type = space.content_types.find('song')
 
-      field = content_type.fields.detect { |f| f.id == 'call_to_action' || 'featured_subtitle' || 'featured_label' }
-      field.omitted = true
-      field.disabled = true
+      fields = content_type.fields.select { |f| %w{call_to_action featured_subtitle featured_label}.include?(f.id) }
+      fields.each do |field|
+        field.omitted = true
+        field.disabled = true
+      end
 
       content_type.save
-      content_type.activate
+      content_type.publish
+
       content_type.fields.destroy('call_to_action')
       content_type.fields.destroy('featured_subtitle')
       content_type.fields.destroy('featured_label')
+
+      content_type.save
+      content_type.publish
     end
   end
 end

--- a/migrations/20180724154803_add_video_collection_to_tags.rb
+++ b/migrations/20180724154803_add_video_collection_to_tags.rb
@@ -6,7 +6,7 @@ class AddVideoCollectionToTags < ContentfulMigrations::Migration
     with_space do |space|
       content_type = space.content_types.find('tag')
 
-      content_type.fields.create(id: 'video_collection', name: 'Video Collection?', type: 'Boolean', required: true)
+      content_type.fields.create(id: 'video_collection', name: 'Video Collection?', type: 'Boolean')
 
       content_type.save
       content_type.publish

--- a/migrations/20180724154803_add_video_collection_to_tags.rb
+++ b/migrations/20180724154803_add_video_collection_to_tags.rb
@@ -1,0 +1,34 @@
+require 'pry'
+
+class AddVideoCollectionToTags < ContentfulMigrations::Migration
+
+  def up
+    with_space do |space|
+      content_type = space.content_types.find('tag')
+
+      content_type.fields.create(id: 'video_collection', name: 'Video Collection?', type: 'Boolean', required: true)
+
+      content_type.save
+      content_type.publish
+    end
+  end
+
+  def down
+    with_space do |space|
+      content_type = space.content_types.find('tag')
+
+      field = content_type.fields.detect { |f| f.id == 'video_collection' }
+      field.omitted = true
+      field.disabled = true
+
+      content_type.save
+      content_type.publish
+
+      content_type.fields.destroy('video_collection')
+
+      content_type.save
+      content_type.publish
+    end
+  end
+
+end


### PR DESCRIPTION
Adds `video_collection` to tags, which designates a tag as being able to be featured as a video collection.

Also fixes a few issues with a migration I haphazardly merged this morning.

---

Corresponds to crdschurch/crds-media#258.