### PR TITLE
DE6292 - Soundcloud URL Uniqueness

### DIFF
--- a/migrations/20180621142700_add_soundcloud_url_to_songs.rb
+++ b/migrations/20180621142700_add_soundcloud_url_to_songs.rb
@@ -4,7 +4,7 @@ class AddSoundcloudUrlToSongs < ContentfulMigrations::Migration
   def up
     with_space do |space|
       content_type = space.content_types.find('song')
-      content_type.fields.create(id: 'soundcloud_url', name: 'Soundcloud URL', type: 'Symbol')
+      content_type.fields.create(id: 'soundcloud_url', name: 'Soundcloud URL', type: 'Symbol', validations: [uniqueness_of])
       content_type.save
       content_type.publish
     end


### PR DESCRIPTION
Update soundcloud_url with uniqueness validation.

I did this retroactively because it's not easy to update fields that already exist. I also made the change through the UI in every environment, so we don't forget when deploying and because it won't block anyone when going to production immediately.