### PR TITLE
US17984-song-copyright

### DIFF
--- a/migrations/20190827112407_update_song.rb
+++ b/migrations/20190827112407_update_song.rb
@@ -1,0 +1,61 @@
+class UpdateSong < ContentfulMigrations::Migration
+  def up
+    with_space do |space|
+
+      content_type = space.content_types.find('song')
+
+       fields = [
+        'ccli_number',
+        'written_by'
+      ]
+
+      fields.each do |field|
+        field = content_type.fields.detect { |f| f.id == field }
+        next unless field
+        field.omitted = true
+        field.disabled = true
+      end
+      
+      content_type.save
+      content_type.publish
+      
+      fields.each do |field|
+        content_type.fields.destroy(field)
+      end
+
+      content_type.fields.create(id: 'description', name: 'Description', type: 'Text')
+
+      content_type.activate
+
+    end
+  end
+
+  def down
+    with_space do |space|
+      content_type = space.content_types.find('song')
+
+       fields = [
+        'description'
+      ]
+
+      fields.each do |field|
+        field = content_type.fields.detect { |f| f.id == field }
+        next unless field
+        field.omitted = true
+        field.disabled = true
+      end
+      
+      content_type.save
+      content_type.publish
+      
+      fields.each do |field|
+        content_type.fields.destroy(field)
+      end
+
+      content_type.fields.create(id: 'ccli_number', name: 'CCLI Number', type: 'Symbol')
+      content_type.fields.create(id: 'written_by', name: 'Written By', type: 'Symbol')
+      
+      content_type.activate
+    end
+  end
+end


### PR DESCRIPTION
### Recent changes
- Adds update_song migration to remove ccli_number and written by fields, while adding description

### Problem
- Songs need to include `description` field
- Songs no longer need to include `ccli_number` or `written_by`

### Solution
- Create an update migration to add `description`, and to remove `ccli_number` and `written_by`

### Test Cases
[dev-test](https://app.contentful.com/spaces/y3a9myzsdjan/environments/dev-test/content_types/song/fields)
