### PR TITLE
DEXXXX Entries Limit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'activesupport'
-gem 'contentful-migrations'
+gem 'contentful-migrations', git: 'https://github.com/monkseal/contentful-migrations.rb', branch: 'defect/DEXXXX-entry-limit'
 gem 'httparty'
 gem 'pry'
 gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/monkseal/contentful-migrations.rb
+  revision: 18d483affbbfa947a6f4bbbf03cdca6abbb5aaba
+  branch: defect/DEXXXX-entry-limit
+  specs:
+    contentful-migrations (0.1.1)
+      contentful-management (~> 2.6)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -10,16 +18,14 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     coderay (1.1.2)
     concurrent-ruby (1.1.4)
-    contentful-management (2.9.1)
+    contentful-management (2.10.0)
       http (> 1.0, < 3.0)
-      json (~> 1.8)
+      json (>= 1.8, < 3.0)
       multi_json (~> 1)
-    contentful-migrations (0.1.2)
-      contentful-management (~> 2.6)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
-    domain_name (0.5.20180417)
+    domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     hashdiff (0.3.8)
     http (2.2.2)
@@ -36,7 +42,7 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (1.5.1)
       concurrent-ruby (~> 1.0)
-    json (1.8.6)
+    json (2.2.0)
     method_source (0.9.2)
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
@@ -82,7 +88,7 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport
-  contentful-migrations
+  contentful-migrations!
   httparty
   pry
   rack (>= 2.0.6)


### PR DESCRIPTION
CFL is only returning 100 migrations by default which is causing migrations to be rerun against ENVs that already have those models in them. Thus, things are failing and this will make them not fail anymore.