### PR TITLE
US17983-music-services

### DIFF
--- a/migrations/20190829140525_add_music_service_links_to_song.rb
+++ b/migrations/20190829140525_add_music_service_links_to_song.rb
@@ -1,0 +1,76 @@
+class AddMusicServiceLinksToSong < ContentfulMigrations::Migration
+  def up
+    with_space do |space|
+      content_type = space.content_types.find('song')
+
+        fields = [
+          'song_select_url',
+          'chords_file',
+          'lyrics_file'
+      ]
+
+      fields.each do |field|
+        field = content_type.fields.detect { |f| f.id == field }
+        next unless field
+        field.omitted = true
+        field.disabled = true
+      end
+      
+      content_type.save
+      content_type.publish
+      
+      fields.each do |field|
+        content_type.fields.destroy(field)
+      end
+
+      content_type.fields.create(id: 'music_service_links', name: 'Music service links', type: 'Object')
+
+      content_type.activate
+
+      widget_id = {
+        'dev-test' => 'WtteiIZ1SLYNwdpEWrQjt',
+        'int' => '7xdunB2TaYood8bTT2QzgS',
+        'demo' => '19bKTiflHnZLNMUYMj6voB',
+        'master' => 'WtteiIZ1SLYNwdpEWrQjt'
+      }[ENV['CONTENTFUL_ENV'] || 'master']
+
+      editor_interface = content_type.editor_interface.default
+      controls = editor_interface.controls
+      controls.detect { |c| c['fieldId'] == 'music_service_links' }['widgetNamespace'] = 'extension'
+      controls.detect { |c| c['fieldId'] == 'music_service_links' }['widgetId'] = widget_id
+      editor_interface.update(controls: controls)
+      editor_interface.reload
+
+    end
+  end
+
+  def down
+    with_space do |space|
+      content_type = space.content_types.find('song')
+
+        fields = [
+          'music_service_links'
+      ]
+
+      fields.each do |field|
+        field = content_type.fields.detect { |f| f.id == field }
+        next unless field
+        field.omitted = true
+        field.disabled = true
+      end
+      
+      content_type.save
+      content_type.publish
+      
+      fields.each do |field|
+        content_type.fields.destroy(field)
+      end
+
+      content_type.fields.create(id: 'song_select_url', name: 'Song Select Url', type: 'Symbol')
+      content_type.fields.create(id: 'lyrics_file', name: 'Lyrics File', type: 'Link', link_type: 'Asset')
+      content_type.fields.create(id: 'chords_file', name: 'Chords File', type: 'Link', link_type: 'Asset')
+
+      content_type.activate
+    end
+  end
+end


### PR DESCRIPTION
### Recent Changes
- Adds migration to remove `song_select_url`, `chords_file`, and `lyrics_file` fields from song model
- Adds `music_service_links` JSON editor ui extension field

### Problem
- Songs need to have links to additional services similar to the Song Select. There are also services called Praise Charts and MultiTracks that need to be added. 
- `songselect_url`, `chords_file`, and `lyrics_file` no longer needed

### Solution
- Add `music_service_links` field to `song` model that utiltizes a JSON editor UI extension. This will be created in a migration

### Corresponding PRs
- Music markup (WIP)
