### PR TITLE
US20708 Onsite Groups

### DIFF
--- a/migrations/20210304090331_add_locations_to_onsite_group_meeting.rb
+++ b/migrations/20210304090331_add_locations_to_onsite_group_meeting.rb
@@ -1,8 +1,13 @@
 class AddLocationsToOnsiteGroupMeeting < ContentfulMigrations::Migration
+
+  include MigrationUtils
+
   def up
     with_space do |space|
       content_type = space.content_types.find('onsite_group_meeting')
       content_type.fields.create(id: 'locations', name: 'Locations', type: 'Array', items: items_of_type('Entry', ['location']))
+      content_type.save
+      content_type.publish
     end
   end
 

--- a/migrations/20210304090331_add_locations_to_onsite_group_meeting.rb
+++ b/migrations/20210304090331_add_locations_to_onsite_group_meeting.rb
@@ -1,0 +1,21 @@
+class AddLocationsToOnsiteGroupMeeting < ContentfulMigrations::Migration
+  def up
+    with_space do |space|
+      content_type = space.content_types.find('onsite_group_meeting')
+      content_type.fields.create(id: 'locations', name: 'Locations', type: 'Array', items: items_of_type('Entry', ['location']))
+    end
+  end
+
+  def down
+    with_space do |space|
+      content_type = space.content_types.find('onsite_group_meeting')
+      field = content_type.fields.detect { |f| f.id == 'locations' }
+      field.omitted = true
+      field.disabled = true
+      content_type.save
+      content_type.fields.destroy('locations')
+      content_type.save
+      content_type.publish
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a new multi-select field for 'locations' to `onsite_group_meeting` so authors can associate a single meeting with multiple locations. This new field will eventually replace the single select location field that exists today. 

### Related PRs

crdschurch/crds-net#2077